### PR TITLE
ImportLog Tracking and Retrieval

### DIFF
--- a/server/src/controllers/ImportLog.controller.ts
+++ b/server/src/controllers/ImportLog.controller.ts
@@ -1,0 +1,14 @@
+import { NextFunction, Request, Response } from "express";
+import { getAllImportLogsService } from "../services/ImportLog.service";
+import { logger } from "../config/logger.config";
+import { StatusCodes } from "http-status-codes";
+
+export const getAllImportLogsHandler = async (req: Request, res: Response, next: NextFunction) => {
+    const logs = await getAllImportLogsService();
+    logger.info("Got all ImportLogs successfully");
+    res.status(StatusCodes.OK).json({
+        success: true,
+        message: "Got all ImportLogs successfully",
+        data: logs
+    });
+}

--- a/server/src/repositories/ImportLog.repository.ts
+++ b/server/src/repositories/ImportLog.repository.ts
@@ -1,9 +1,8 @@
 import { logger } from "../config/logger.config";
-import { CreateImportLogDTO } from "../dtos/dtos";
-import ImportLog from "../models/importLog.model";
+import ImportLog, { IImportLog } from "../models/importLog.model";
 
 
-export const createImportLog = async (paylod: CreateImportLogDTO) => {
+export const createImportLog = async (paylod: Partial<IImportLog>) => {
     try {
         await ImportLog.create(paylod);
     } catch (error) {

--- a/server/src/repositories/ImportLog.repository.ts
+++ b/server/src/repositories/ImportLog.repository.ts
@@ -12,11 +12,6 @@ export const createImportLog = async (paylod: CreateImportLogDTO) => {
 }
 
 export const getAllImportLogs = async () => {
-    try {
-        const logs = await ImportLog.find({});
-        return logs;
-    } catch (error) {
-        logger.error("Something went wrong while getting ImportLogs!");
-        return error;
-    }
+    const logs = await ImportLog.find({});
+    return logs;
 }

--- a/server/src/routers/v1/importLog.router.ts
+++ b/server/src/routers/v1/importLog.router.ts
@@ -1,0 +1,8 @@
+import express from 'express';
+import { getAllImportLogsHandler } from '../../controllers/ImportLog.controller';
+
+const importLogRouter = express.Router();
+
+importLogRouter.get('/', getAllImportLogsHandler);
+
+export default importLogRouter;

--- a/server/src/routers/v1/index.ts
+++ b/server/src/routers/v1/index.ts
@@ -1,6 +1,8 @@
 import express from 'express';
+import importLogRouter from './importLog.router';
 
 const router = express.Router();
 
+router.use('/importlogs', importLogRouter);
 
 export default router;

--- a/server/src/services/ImportLog.service.ts
+++ b/server/src/services/ImportLog.service.ts
@@ -1,0 +1,5 @@
+import { getAllImportLogs } from "../repositories/ImportLog.repository";
+
+export const getAllImportLogsService = async () => {
+    return await getAllImportLogs();
+}

--- a/server/src/workers/job.worker.ts
+++ b/server/src/workers/job.worker.ts
@@ -4,6 +4,7 @@ import { JOB_QUEUE } from "../queues/job.queue";
 import { serverConfig } from "../config";
 import { createOrUpdateJob } from "../repositories/job.repository";
 import { IFailedJob } from "../models/importLog.model";
+import { createImportLog } from "../repositories/ImportLog.repository";
 
 let newJobs = 0;
 let updatedJobs = 0;
@@ -37,7 +38,14 @@ export const startWorker = () => {
         if (!totalFetched) return;
 
         // call api to create import_log
-
+        await createImportLog({
+            timestamp: new Date(),
+            totalFetched,
+            newJobs,
+            updatedJobs,
+            failedJobs,
+        });
+        
         totalFetched = 0;
         newJobs = 0;
         updatedJobs = 0;


### PR DESCRIPTION
### ✅ Summary
This PR introduces functionality to log import job metadata and retrieve historical import logs via an API endpoint.

---

### 📦 Changes

#### 1. **Worker Integration**
- Added `createImportLog` call in `job.worker.ts` to log:
  - `timestamp`, `totalFetched`, `newJobs`, `updatedJobs`, and `failedJobs`

#### 2. **Repository Layer**
- Refactored `createImportLog`:
  - Removed dependency on DTO
  - Accepts `Partial<IImportLogs>` for flexibility
- Simplified `getAllImportLogs`: removed unnecessary try-catch

#### 3. **Service Layer**
- Added `getAllImportLogsService` to bridge between controller and repository

#### 4. **Controller Layer**
- Implemented `getAllImportLogsHandler` controller
  - Handles GET request to fetch import logs
  - Responds with logs and success message

#### 5. **Routing**
- Introduced new route `/importlogs`
- Hooked into `v1/index.ts`

---

### 🧪 Testing
- Manually tested: verified import log creation and retrieval via endpoint

---

### 📁 Affected Files
- `job.worker.ts`
- `ImportLog.repository.ts`
- `ImportLog.service.ts`
- `ImportLog.controller.ts`
- `v1/importLog.router.ts`
- `v1/index.ts`

---

### 📌 Notes
- `CreateImportLogDTO` was removed for now to allow direct `Partial<IImportLogs>` usage
- Minimal logging added in controller for visibility

---

### 🧹 Clean-Up
- Removed unused try-catch from repository fetch function

---

### 🎯 Endpoint
`GET /v1/importlogs` – Returns all import logs
